### PR TITLE
Fixed bugs. Now it runs properly

### DIFF
--- a/run_all_docker_excessive.sh
+++ b/run_all_docker_excessive.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 IFS=$'\n' read -d '' -r -a lines < resources.txt
 
-for i in {1..$1} :
+for i in {1..$1..1} :
 do
   for i in "${lines[@]}"
   do


### PR DESCRIPTION
To run it: ./run_all_docker_excessive.sh <number>
The "number" refers to the number of times the resorces.txt will be read. So if there's 10 urls in resources.txt and you type './run_all_docker_excessive.sh 2' then 20 containers will be launched.